### PR TITLE
feat(codec): force bytelizer_alloc calling bytelizer_clear at last

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 .vscode/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ bytelizer_alloc(_ctx, 64); {
   bytelizer_put_uint16(_ctx, 0x5678);
   bytelizer_put_uint32(_ctx, 0xDEADBEEF);
 }
+bytelizer_clear(_ctx);
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ bytelizer_alloc(_ctx, 64); {
   bytelizer_put_uint16(_ctx, 0x5678);
   bytelizer_put_uint32(_ctx, 0xDEADBEEF);
 }
-bytelizer_clear(_ctx);
+bytelizer_destroy(_ctx);
 
 ```
 

--- a/src/advanced.h
+++ b/src/advanced.h
@@ -286,10 +286,10 @@ _inline static size_t __get_prefix_length_by_type(bytelizer_prefix_t prefix) {
     case prefix_uint16le: return 2;
     case prefix_uint32be:
     case prefix_uint32le: return 4;
+    default:
+      __bytelizer_log("wrong prefix type enum %d", prefix);
+      return 0;
   }
-
-  __bytelizer_log("wrong prefix type");
-  return 0;
 }
 
 static void __put_prefix(bytelizer_ctx_t* ctx,

--- a/src/codec.c
+++ b/src/codec.c
@@ -220,7 +220,7 @@ uint32_t bytelizer_copy_to(void* userdata, bytelizer_ctx_t* ctx, bytelizer_callb
   return ctx->total_length;
 }
 
-void bytelizer_destroy(bytelizer_ctx_t* ctx) {
+void bytelizer_destroy_unsafe(bytelizer_ctx_t* ctx) {
 
   if(ctx->blocks == NULL) return;
 

--- a/src/codec.h
+++ b/src/codec.h
@@ -25,9 +25,9 @@ typedef struct _bytelizer_block_t {
 
 typedef struct _bytelizer_ctx_t {
   uint32_t total_length;
-  uint8_t* stack;
   uint32_t stack_wrotes;
   uint32_t stack_length;
+  uint8_t* stack;
   bytelizer_list_ctx_t* blocks;
   uint8_t* cursor;
   uint32_t* counter;
@@ -38,10 +38,9 @@ typedef void (* bytelizer_callback_copy_t)(void* userdata, uint8_t* buffer, size
 /**
  * @brief bytelizer initialize
  * @param ctx the bytelizer context
- * @param buffer the buffer name
- * @param length the buffer length
+ * @param size the stack buffer size
  */
-#define bytelizer_alloc(ctx, size) \
+#define bytelizer_alloc(ctx, size) { \
   uint8_t ctx##_buf[size]; \
   bytelizer_ctx_t* ctx = &(bytelizer_ctx_t) { \
     .stack = ctx##_buf, \
@@ -56,7 +55,7 @@ typedef void (* bytelizer_callback_copy_t)(void* userdata, uint8_t* buffer, size
  * @brief release heap blocks and clean
  * @param ctx the bytelizer context
  */
-#define bytelizer_clear(ctx) { \
+#define bytelizer_clear(ctx) \
     bytelizer_destroy(ctx); \
     ctx->stack_wrotes = 0; \
     ctx->total_length = 0; \

--- a/src/codec.h
+++ b/src/codec.h
@@ -25,9 +25,9 @@ typedef struct _bytelizer_block_t {
 
 typedef struct _bytelizer_ctx_t {
   uint32_t total_length;
+  uint8_t* stack;
   uint32_t stack_wrotes;
   uint32_t stack_length;
-  uint8_t* stack;
   bytelizer_list_ctx_t* blocks;
   uint8_t* cursor;
   uint32_t* counter;
@@ -71,7 +71,7 @@ typedef void (* bytelizer_callback_copy_t)(void* userdata, uint8_t* buffer, size
  * @param buffer the buffer pointer
  * @param size the buffer size
  */
-#define bytelizer_attach(ctx, buffer, size) \
+#define bytelizer_attach(ctx, buffer, size) { \
   bytelizer_ctx_t* ctx = &(bytelizer_ctx_t) { \
     .stack = buffer, \
     .stack_length = size, \
@@ -80,6 +80,20 @@ typedef void (* bytelizer_callback_copy_t)(void* userdata, uint8_t* buffer, size
     .blocks = NULL, \
     .cursor = buffer, \
   }; { ctx->counter = &ctx->stack_wrotes; }
+
+/**
+ * @brief release heap blocks and clean
+ * @param ctx the bytelizer context
+ */
+#define bytelizer_detach(ctx) \
+    bytelizer_destroy(ctx); \
+    ctx->stack_wrotes = 0; \
+    ctx->total_length = 0; \
+    ctx->blocks = NULL; \
+    ctx->cursor = ctx->stack; \
+    ctx->counter = &ctx->stack_wrotes; \
+    memset(ctx->stack, 0, ctx->stack_length); \
+  }
 
 /**
  * @brief get bytelizer length

--- a/src/codec.h
+++ b/src/codec.h
@@ -63,7 +63,7 @@ typedef void (* bytelizer_callback_copy_t)(void* userdata, uint8_t* buffer, size
  * @param ctx the bytelizer context
  */
 #define bytelizer_clear_unsafe(ctx) \
-    bytelizer_destroy(ctx); \
+    bytelizer_destroy_unsafe(ctx); \
     ctx->stack_wrotes = 0; \
     ctx->total_length = 0; \
     ctx->blocks = NULL; \
@@ -106,7 +106,7 @@ typedef void (* bytelizer_callback_copy_t)(void* userdata, uint8_t* buffer, size
  * @param ctx the bytelizer context
  */
 #define bytelizer_detach_unsafe(ctx) \
-    bytelizer_destroy(ctx); \
+    bytelizer_destroy_unsafe(ctx); \
     ctx->stack_wrotes = 0; \
     ctx->total_length = 0; \
     ctx->blocks = NULL; \
@@ -308,9 +308,11 @@ bool bytelizer_ensure_available(bytelizer_ctx_t* ctx, size_t request);
 uint32_t bytelizer_copy_to(void* userdata, bytelizer_ctx_t* ctx, bytelizer_callback_copy_t callback);
 
 /**
- * @brief dectroy bytelizer
+ * @brief destroy bytelizer without pairing
  * @param ctx the bytelizer context
 */
-void bytelizer_destroy(bytelizer_ctx_t* ctx);
+void bytelizer_destroy_unsafe(bytelizer_ctx_t* ctx);
+
+#define bytelizer_destroy(ctx) bytelizer_destroy_unsafe(ctx); }
 
 #endif /* _BYTELIZER_CODEC_H */

--- a/src/codec.h
+++ b/src/codec.h
@@ -36,11 +36,11 @@ typedef struct _bytelizer_ctx_t {
 typedef void (* bytelizer_callback_copy_t)(void* userdata, uint8_t* buffer, size_t length);
 
 /**
- * @brief bytelizer initialize
+ * @brief bytelizer initialize without force clear
  * @param ctx the bytelizer context
  * @param size the stack buffer size
  */
-#define bytelizer_alloc(ctx, size) { \
+#define bytelizer_alloc_unsafe(ctx, size) \
   uint8_t ctx##_buf[size]; \
   bytelizer_ctx_t* ctx = &(bytelizer_ctx_t) { \
     .stack = ctx##_buf, \
@@ -52,10 +52,17 @@ typedef void (* bytelizer_callback_copy_t)(void* userdata, uint8_t* buffer, size
   }; { ctx->counter = &ctx->stack_wrotes; memset(ctx##_buf, 0, size); }
 
 /**
- * @brief release heap blocks and clean
+ * @brief bytelizer initialize
+ * @param ctx the bytelizer context
+ * @param size the stack buffer size
+ */
+#define bytelizer_alloc(ctx, size) { bytelizer_alloc_unsafe(ctx, size)
+
+/**
+ * @brief release heap blocks and clean without pairing
  * @param ctx the bytelizer context
  */
-#define bytelizer_clear(ctx) \
+#define bytelizer_clear_unsafe(ctx) \
     bytelizer_destroy(ctx); \
     ctx->stack_wrotes = 0; \
     ctx->total_length = 0; \
@@ -63,15 +70,20 @@ typedef void (* bytelizer_callback_copy_t)(void* userdata, uint8_t* buffer, size
     ctx->cursor = ctx->stack; \
     ctx->counter = &ctx->stack_wrotes; \
     memset(ctx->stack, 0, ctx->stack_length); \
-  }
 
 /**
- * @brief attach a buffer
+ * @brief release heap blocks and clean
+ * @param ctx the bytelizer context
+ */
+#define bytelizer_clear(ctx) bytelizer_clear_unsafe(ctx) }
+
+/**
+ * @brief attach a buffer without force detach
  * @param ctx the bytelizer context
  * @param buffer the buffer pointer
  * @param size the buffer size
  */
-#define bytelizer_attach(ctx, buffer, size) { \
+#define bytelizer_attach_unsafe(ctx, buffer, size) \
   bytelizer_ctx_t* ctx = &(bytelizer_ctx_t) { \
     .stack = buffer, \
     .stack_length = size, \
@@ -82,10 +94,18 @@ typedef void (* bytelizer_callback_copy_t)(void* userdata, uint8_t* buffer, size
   }; { ctx->counter = &ctx->stack_wrotes; }
 
 /**
- * @brief release heap blocks and clean
+ * @brief attach a buffer
+ * @param ctx the bytelizer context
+ * @param buffer the buffer pointer
+ * @param size the buffer size
+ */
+#define bytelizer_attach(ctx, buffer, size) { bytelizer_attach_unsafe(ctx, buffer, size)
+
+/**
+ * @brief release heap blocks and clean without pairing
  * @param ctx the bytelizer context
  */
-#define bytelizer_detach(ctx) \
+#define bytelizer_detach_unsafe(ctx) \
     bytelizer_destroy(ctx); \
     ctx->stack_wrotes = 0; \
     ctx->total_length = 0; \
@@ -93,7 +113,12 @@ typedef void (* bytelizer_callback_copy_t)(void* userdata, uint8_t* buffer, size
     ctx->cursor = ctx->stack; \
     ctx->counter = &ctx->stack_wrotes; \
     memset(ctx->stack, 0, ctx->stack_length); \
-  }
+
+/**
+ * @brief release heap blocks and clean
+ * @param ctx the bytelizer context
+ */
+#define bytelizer_detach(ctx) bytelizer_detach_unsafe(ctx) }
 
 /**
  * @brief get bytelizer length

--- a/src/debug/log.c
+++ b/src/debug/log.c
@@ -9,7 +9,7 @@
 
 #include "log.h"
 
-static void __placeholder_log(const char*) { /* do nothing */ }
+static void __placeholder_log(const char* _) { /* do nothing */ }
 bytelizer_log_callback_t __bytelizer_log_callback = &__placeholder_log;
 
 void bytelizer_set_log_callback(bytelizer_log_callback_t cb) {

--- a/src/debug/log.c
+++ b/src/debug/log.c
@@ -9,7 +9,7 @@
 
 #include "log.h"
 
-static void __placeholder_log(const char*) { /* do nothing */}
+static void __placeholder_log(const char*) { /* do nothing */ }
 bytelizer_log_callback_t __bytelizer_log_callback = &__placeholder_log;
 
 void bytelizer_set_log_callback(bytelizer_log_callback_t cb) {

--- a/src/protobuf.c
+++ b/src/protobuf.c
@@ -91,7 +91,7 @@ void bytelizer_put_pbstruct(bytelizer_ctx_t* ctx, const bytelizer_pbfield_t* pbr
 
         // copy data
         bytelizer_put_bytelizer(ctx, _ctx);
-        bytelizer_destroy(_ctx);
+        bytelizer_clear(_ctx);
         break;
       }
 

--- a/src/protobuf.c
+++ b/src/protobuf.c
@@ -91,7 +91,7 @@ void bytelizer_put_pbstruct(bytelizer_ctx_t* ctx, const bytelizer_pbfield_t* pbr
 
         // copy data
         bytelizer_put_bytelizer(ctx, _ctx);
-        bytelizer_clear(_ctx);
+        bytelizer_destroy(_ctx);
         break;
       }
 


### PR DESCRIPTION
如此一来即不会有失误忘记`destroy`的情形了，因为不调用`bytelizer_clear`会导致大括号数量对不上，无法通过编译。