### PR TITLE
fix "error: label at end of compound statement" with gcc8

### DIFF
--- a/src/protobuf.c
+++ b/src/protobuf.c
@@ -182,7 +182,8 @@ bool bytelizer_get_pbstruct(bytelizer_ctx_t* ctx, bytelizer_pbfield_t* pbroot) {
         break;
       }
 
-      default:
+      default: 
+        break;
     }
 
     ++pbroot;


### PR DESCRIPTION
```
./Src/bytelizer/src/protobuf.c: In function 'bytelizer_get_pbstruct':
./Src/bytelizer/src/protobuf.c:185:7: error: label at end of compound statement
       default:
```