### PR TITLE
Enhancements: Add Float/Double Support, Fix GCC 8 Warnings, Update Notes...

### DIFF
--- a/src/advanced.h
+++ b/src/advanced.h
@@ -111,6 +111,22 @@ typedef enum {
   bytelizer_put_value(ctx, int64_t, bitwise_le64(value))
 
 /**
+ * @brief put float into the buffer as little endian
+ * @param ctx the bytelizer context
+ * @param value the value
+*/
+#define bytelizer_put_float_le(ctx, value) \
+  bytelizer_put_value(ctx, float, bitwise_le32(value))
+
+/**
+ * @brief put double into the buffer as little endian
+ * @param ctx the bytelizer context
+ * @param value the value
+*/
+#define bytelizer_put_double_le(ctx, value) \
+  bytelizer_put_value(ctx, double, bitwise_le64(value))
+
+/**
  * @brief put uint16 into the buffer as big endian
  * @param ctx the bytelizer context
  * @param value the value
@@ -157,6 +173,22 @@ typedef enum {
 */
 #define bytelizer_put_int64_be(ctx, value) \
   bytelizer_put_value(ctx, int64_t, bitwise_be64(value))
+
+/**
+ * @brief put float into the buffer as big endian
+ * @param ctx the bytelizer context
+ * @param value the value
+*/
+#define bytelizer_put_float_be(ctx, value) \
+  bytelizer_put_value(ctx, float, bitwise_be32(value))
+
+/**
+ * @brief put double into the buffer as big endian
+ * @param ctx the bytelizer context
+ * @param value the value
+*/
+#define bytelizer_put_double_be(ctx, value) \
+  bytelizer_put_value(ctx, double, bitwise_be64(value))
 
 /**
  * @brief get uint16 from the buffer as little endian
@@ -219,6 +251,26 @@ typedef enum {
 }
 
 /**
+ * @brief get float from the buffer as little endian
+ * @param ctx the bytelizer context
+ * @param value the value
+*/
+#define bytelizer_get_float_le(ctx, value) { \
+  bytelizer_get_value(ctx, float, value); \
+  *value = bitwise_le32(*value); \
+}
+
+/**
+ * @brief get double from the buffer as little endian
+ * @param ctx the bytelizer context
+ * @param value the value
+*/
+#define bytelizer_get_double_le(ctx, value) { \
+  bytelizer_get_value(ctx, double, value); \
+  *value = bitwise_le64(*value); \
+}
+
+/**
  * @brief get uint16 from the buffer as big endian
  * @param ctx the bytelizer context
  * @param value the value
@@ -275,6 +327,26 @@ typedef enum {
 */
 #define bytelizer_get_int64_be(ctx, value) { \
   bytelizer_get_value(ctx, int64_t, value); \
+  *value = bitwise_be64(*value); \
+}
+
+/**
+ * @brief get float from the buffer as big endian
+ * @param ctx the bytelizer context
+ * @param value the value
+*/
+#define bytelizer_get_float_be(ctx, value) { \
+  bytelizer_get_value(ctx, float, value); \
+  *value = bitwise_be32(*value); \
+}
+
+/**
+ * @brief get double from the buffer as big endian
+ * @param ctx the bytelizer context
+ * @param value the value
+*/
+#define bytelizer_get_double_be(ctx, value) { \
+  bytelizer_get_value(ctx, double, value); \
   *value = bitwise_be64(*value); \
 }
 
@@ -424,7 +496,7 @@ uint8_t* value, uint32_t length, bytelizer_prefix_t prefix) {
 
     // teardown one byte into high and low parts
     // example: 0xE9 became 0xE and 0x9
-    uint8_t _part = _byte >> (1 - ((_counter & 1)) << 2);
+    uint8_t _part = _byte >> ((1 - ((_counter & 1))) << 2);
 
     // match the result from the hex table
     ctx->cursor[_counter] = _hex_table[_part & 0x0F];

--- a/src/codec.h
+++ b/src/codec.h
@@ -246,12 +246,28 @@ typedef void (* bytelizer_callback_copy_t)(void* userdata, uint8_t* buffer, size
   bytelizer_put_value(ctx, int8_t, value)
 
 /**
+ * @brief get int8_t from the buffer as platform endianness
+ * @param ctx the bytelizer context
+ * @param value the value
+*/
+#define bytelizer_get_int8(ctx, value) \
+  bytelizer_get_value(ctx, int8_t, value)
+
+/**
  * @brief put int16 into the buffer as platform endianness
  * @param ctx the bytelizer context
  * @param value the value
 */
 #define bytelizer_put_int16(ctx, value) \
   bytelizer_put_value(ctx, int16_t, value)
+
+/**
+ * @brief get int16_t from the buffer as platform endianness
+ * @param ctx the bytelizer context
+ * @param value the value
+*/
+#define bytelizer_get_int16(ctx, value) \
+  bytelizer_get_value(ctx, int16_t, value)
 
 /**
  * @brief put int32 into the buffer as platform endianness
@@ -262,12 +278,29 @@ typedef void (* bytelizer_callback_copy_t)(void* userdata, uint8_t* buffer, size
   bytelizer_put_value(ctx, int32_t, value)
 
 /**
+ * @brief get int32_t from the buffer as platform endianness
+ * @param ctx the bytelizer context
+ * @param value the value
+*/
+#define bytelizer_get_int32(ctx, value) \
+  bytelizer_get_value(ctx, int32_t, value)
+
+
+/**
  * @brief put int64 into the buffer as platform endianness
  * @param ctx the bytelizer context
  * @param value the value
 */
 #define bytelizer_put_int64(ctx, value) \
   bytelizer_put_value(ctx, int64_t, value)
+
+/**
+ * @brief get int64_t from the buffer as platform endianness
+ * @param ctx the bytelizer context
+ * @param value the value
+*/
+#define bytelizer_get_int64(ctx, value) \
+  bytelizer_get_value(ctx, int64_t, value)
 
 /**
  * @brief put float into the buffer as platform endianness

--- a/src/codec.h
+++ b/src/codec.h
@@ -269,6 +269,37 @@ typedef void (* bytelizer_callback_copy_t)(void* userdata, uint8_t* buffer, size
   bytelizer_put_value(ctx, int64_t, value)
 
 /**
+ * @brief put float into the buffer as platform endianness
+ * @param ctx the bytelizer context
+ * @param value the value
+*/
+#define bytelizer_put_float(ctx, value) \
+  bytelizer_put_value(ctx, float, value)
+  
+/**
+ * @brief get float into the buffer as platform endianness
+ * @param ctx the bytelizer context
+ * @param value the value
+*/
+#define bytelizer_get_float(ctx, value) \
+  bytelizer_get_value(ctx, float, value)
+
+/**
+ * @brief put double into the buffer as platform endianness
+ * @param ctx the bytelizer context
+ * @param value the value
+*/
+#define bytelizer_put_double(ctx, value) \
+  bytelizer_put_value(ctx, double, value)
+/**
+ * @brief get double into the buffer as platform endianness
+ * @param ctx the bytelizer context
+ * @param value the value
+*/
+#define bytelizer_get_double(ctx, value) \
+  bytelizer_get_value(ctx, double, value)
+
+/**
  * @brief put string into buffer
  * @param ctx the bytelizer context
  * @param value the value

--- a/src/codec.h
+++ b/src/codec.h
@@ -13,6 +13,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <string.h> 
 
 #include "list.h"
 

--- a/src/codec.h
+++ b/src/codec.h
@@ -174,7 +174,7 @@ typedef void (* bytelizer_callback_copy_t)(void* userdata, uint8_t* buffer, size
   value = *(type *)cursor;
 
 /**
- * @brief put uint8
+ * @brief put uint8 into the buffer as platform endianness
  * @param ctx the bytelizer context
  * @param value the value
 */
@@ -182,7 +182,7 @@ typedef void (* bytelizer_callback_copy_t)(void* userdata, uint8_t* buffer, size
   bytelizer_put_value(ctx, uint8_t, value)
 
 /**
- * @brief get uint8
+ * @brief get uint8 from the buffer as platform endianness
  * @param ctx the bytelizer context
  * @param value the value
 */
@@ -198,7 +198,7 @@ typedef void (* bytelizer_callback_copy_t)(void* userdata, uint8_t* buffer, size
   bytelizer_put_value(ctx, uint16_t, value)
 
 /**
- * @brief get uint16 into the buffer as platform endianness
+ * @brief get uint16 from the buffer as platform endianness
  * @param ctx the bytelizer context
  * @param value the value
 */
@@ -214,7 +214,7 @@ typedef void (* bytelizer_callback_copy_t)(void* userdata, uint8_t* buffer, size
   bytelizer_put_value(ctx, uint32_t, value)
 
 /**
- * @brief get uint32 into the buffer as platform endianness
+ * @brief get uint32 from the buffer as platform endianness
  * @param ctx the bytelizer context
  * @param value the value
 */
@@ -230,7 +230,7 @@ typedef void (* bytelizer_callback_copy_t)(void* userdata, uint8_t* buffer, size
   bytelizer_put_value(ctx, uint64_t, value)
 
 /**
- * @brief get uint64 into the buffer as platform endianness
+ * @brief get uint64 from the buffer as platform endianness
  * @param ctx the bytelizer context
  * @param value the value
 */
@@ -278,7 +278,7 @@ typedef void (* bytelizer_callback_copy_t)(void* userdata, uint8_t* buffer, size
   bytelizer_put_value(ctx, float, value)
   
 /**
- * @brief get float into the buffer as platform endianness
+ * @brief get float from the buffer as platform endianness
  * @param ctx the bytelizer context
  * @param value the value
 */
@@ -293,7 +293,7 @@ typedef void (* bytelizer_callback_copy_t)(void* userdata, uint8_t* buffer, size
 #define bytelizer_put_double(ctx, value) \
   bytelizer_put_value(ctx, double, value)
 /**
- * @brief get double into the buffer as platform endianness
+ * @brief get double from the buffer as platform endianness
  * @param ctx the bytelizer context
  * @param value the value
 */

--- a/src/protobuf.c
+++ b/src/protobuf.c
@@ -182,7 +182,8 @@ bool bytelizer_get_pbstruct(bytelizer_ctx_t* ctx, bytelizer_pbfield_t* pbroot) {
         break;
       }
 
-      default:
+      default: 
+        break;
     }
 
     ++pbroot;


### PR DESCRIPTION
1. add float and double type
```
bytelizer_put_float
bytelizer_get_float
bytelizer_put_double
bytelizer_get_double
bytelizer_put_float_le
bytelizer_put_double_le
bytelizer_put_float_be
bytelizer_put_double_be
```
2. Eliminate warning: 'implicit declaration of function 'memset' on gcc8
3. Eliminate warning: suggest parentheses around '-' inside '<<' on gcc8
```
./Src/bytelizer/src/advanced.h: In function 'bytelizer_put_bytestr':
./Src/bytelizer/src/advanced.h:499:33: warning: suggest parentheses around '-' inside '<<' [-Wparentheses]
     uint8_t _part = _byte >> (1 - ((_counter & 1)) << 2);
```
4. update note.
```
get uint16 into the buffer as platform endianness -> get uint16 from the buffer as platform endianness
...
```
5. add macro definitions
```
bytelizer_get_int8
bytelizer_get_int16
bytelizer_get_int32
bytelizer_get_int64
```